### PR TITLE
Version 2017.2.5 readme only

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -4,3 +4,4 @@ Francesco Levorato (flevour) <git@flevour.net>
 Andy Balaam (andybalaam) <mail@artificialworlds.net>
 Patrick Lucas <me@patricklucas.com>
 Stefan65
+Ben Webb (benjaminedwardwebb) <benjaminedwardwebb@gmail.com>

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # intellij-idea-community
 .deb Packages of IntelliJ IDEA Community Edition for Ubuntu
 
-The latest upstream version is 2017.2.4 which is included in the package version 2017.2.4.
+The latest upstream version is 2017.2.5 which is included in the package version 2017.2.5.
 
 ## Adding the ppa to Ubuntu
 
@@ -13,20 +13,20 @@ sudo apt-get install intellij-idea-community
 
 ## Updating the package
 
-To update the version follow the following steps (the old version is here 2017.2.3 and the new one 15.0.2):
+To update the version follow these steps. Replace all instances of `[year].[major].[minor]` with the new version numbers (e.g., 2017.2.5++).
 
  1. Fork the repo
  2. Create your own feature branch
 
  ```
- git checkout -b version-2017.2.4
+ git checkout -b version-[year].[major].[minor]
  ```
 
  3. Rename the following
 
  ```
- mv intellij-idea-community_2017.2.3 intellij-idea-community_2017.2.4
- mv intellij-idea-community_2017.2.3.orig.tar.gz intellij-idea-community_2017.2.4.orig.tar.gz
+ mv intellij-idea-community_2017.2.5 intellij-idea-community_[year].[major].[minor]
+ mv intellij-idea-community_2017.2.5.orig.tar.gz intellij-idea-community_[year].[major].[minor].orig.tar.gz
  ```
 
  4. Edit the README.md and update the version numbers
@@ -34,7 +34,7 @@ To update the version follow the following steps (the old version is here 2017.2
  5. Go into the build files directory
 
  ```
- cd intellij-idea-community_2017.2.4/debian
+ cd intellij-idea-community_[year].[major].[minor]/debian
  ```
 
  6. Edit the changelog file and prepend a new changelog entry. You can just copy an old one and update the values in it
@@ -62,13 +62,13 @@ To update the version follow the following steps (the old version is here 2017.2
  11. Remove the old files
 
  ```
- rm intellij-idea-community_2017.2.3-1*
+ rm intellij-idea-community_2017.2.5-1*
  ```
 
  12. Install the package to test it
 
  ```
- sudo dpkg -i intellij-idea-community_2017.2.4_all.deb
+ sudo dpkg -i intellij-idea-community_[year].[major].[minor]_all.deb
  ```
 
  13. If everything works, add yourself to the CONTRIBUTORS.txt
@@ -77,20 +77,20 @@ To update the version follow the following steps (the old version is here 2017.2
 
  ```
  git add -A
- git commit -m "Version 2017.2.4"
+ git commit -m "Version [year].[major].[minor]"
  ```
 
  15. Push to the branch
 
  ```
- git push origin version-2017.2.4
+ git push origin version-[year].[major].[minor]
  ```
 
  16. Create new pull request
 
 ## Automatically do steps 2 to 12
 
-Run `./update-new-version.sh 2017.2.3 2017.2.4`
+Run `./update-new-version.sh 2017.2.5 [year].[major].[minor]`
 
 ## Setting up the build environment
 

--- a/update-new-version.sh
+++ b/update-new-version.sh
@@ -13,6 +13,10 @@ function main {
     mv intellij-idea-community_{$old,$new}
     mv intellij-idea-community_{$old,$new}.orig.tar.gz
 
+    # 4. Edit README.md to update latest version number.
+    sed "s/$old/$new/g" ./README.md > ./README.md.tmp 
+    mv ./README.md.tmp ./README.md
+
     echo "intellij-idea-community ($new-1) artful; urgency=low
 
   * Upstream Version $new


### PR DESCRIPTION
Hi Marcel. Thanks for setting this up, it's great!!

Just updating and automating the README.md edits, to calm my OCD haha. 

Now the example update steps should use `2017.2.5` as current version and `[year].[major].[minor]` for the future release (robust against `2017.2.6` or `2017.3.1` or `2018.1` etc.).

Let me know if you have any thoughts or dislike the changes.